### PR TITLE
Add opponent character win rate matrix example query

### DIFF
--- a/examples/win_rate_character_matrix.sql
+++ b/examples/win_rate_character_matrix.sql
@@ -1,0 +1,65 @@
+-- Calculate win rate against all characters encountered
+-- Supplement your own player code (in place of 'FRTZ#931') on lines 13 and 28
+
+WITH
+totals AS (
+  SELECT
+  character,
+    COUNT(*) total_games_played,
+    SUM(winner) total_wins,
+    ROUND((SUM(winner) * 100.0)/(COUNT(*) *100.0),4) * 100 AS total_win_rate
+  FROM players
+-- Change this to your own player code
+  WHERE code = 'FRTZ#931'
+  GROUP BY character),
+character_mus AS (
+  SELECT
+    me.character,
+    COUNT(*) AS games_played,
+    SUM(me.winner) AS wins,
+    ROUND((SUM(me.winner) * 100.0)/(COUNT(*) * 100.0),4) * 100.0 AS win_rate,
+    op.character AS op_character
+  FROM players me, players op, games
+  WHERE op.id != me.id
+    AND me.game_id = op.game_id
+    AND me.game_id = games.id
+    AND NOT games.is_teams
+  -- Change this to your own player code
+  AND me.code = 'FRTZ#931'
+  GROUP BY me.character, op_character
+  ORDER BY win_rate DESC),
+  reduce_set AS (
+  SELECT * FROM character_mus
+  -- Disregard low sample size MU's
+  WHERE games_played > 5)
+SELECT t.*,
+  MAX(CASE WHEN op_character = 'FOX' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS fox,
+  MAX(CASE WHEN op_character = 'FALCO' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS falco,
+  MAX(CASE WHEN op_character = 'MARTH' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS marth,
+  MAX(CASE WHEN op_character = 'SHEIK' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS sheik,
+  MAX(CASE WHEN op_character = 'CAPTAIN_FALCON' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS captain_falcon,
+  MAX(CASE WHEN op_character = 'JIGGLYPUFF' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS jigglypuff,
+  MAX(CASE WHEN op_character = 'PEACH' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS peach,
+  MAX(CASE WHEN op_character = 'PIKACHU' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS pikachu,
+  MAX(CASE WHEN op_character = 'YOSHI' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS yoshi,
+  MAX(CASE WHEN op_character = 'SAMUS' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS samus,
+  MAX(CASE WHEN op_character = 'ICE_CLIMBERS' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS ice_climbers,
+  MAX(CASE WHEN op_character = 'DR_MARIO' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS doctor_mario,
+  MAX(CASE WHEN op_character = 'LUIGI' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS luigi,
+  MAX(CASE WHEN op_character = 'MARIO' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS mario,
+  MAX(CASE WHEN op_character = 'YOUNG_LINK' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS young_link,
+  MAX(CASE WHEN op_character = 'GANONDORF' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS ganondorf,
+  MAX(CASE WHEN op_character = 'LINK' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS link,
+  MAX(CASE WHEN op_character = 'DONKEY_KONG' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS donkey_kong,
+  MAX(CASE WHEN op_character = 'MEWTWO' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS mew_two,
+  MAX(CASE WHEN op_character = 'ROY' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS roy,
+  MAX(CASE WHEN op_character = 'GAME_AND_WATCH' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS game_and_watch,
+  MAX(CASE WHEN op_character = 'ZELDA' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS zelda,
+  MAX(CASE WHEN op_character = 'PICHU' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS pichu,
+  MAX(CASE WHEN op_character = 'NESS' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS ness,
+  MAX(CASE WHEN op_character = 'BOWSER' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS bowser,
+  MAX(CASE WHEN op_character = 'KIRBY' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS kirby
+FROM reduce_set
+JOIN totals t USING(character)
+GROUP BY character
+ORDER BY AVG(total_win_rate) DESC;


### PR DESCRIPTION
## What is the purpose of this PR?
This PR adds an example query which calculates each of your played character's win rates against every member of the cast, across all games played.

This query could likely be improved given a bit of optimization but I felt like it was good enough to warrant potential inclusion.

## What is example output of this query?
```
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+----------------+------------------+----------------+----------------+----------------+----------------+----------------+--------------+----------------+----------------+----------------+----------------+----------------+----------------+---------------+--------------+---------------+----------------+--------------+-------+--------------+----------------+-------+
| character      | total_games_played | total_wins | total_win_rate | fox              | falco            | marth            | sheik          | captain_falcon   | jigglypuff     | peach          | pikachu        | yoshi          | samus          | ice_climbers | doctor_mario   | luigi          | mario          | young_link     | ganondorf      | link           | donkey_kong   | mew_two      | roy           | game_and_watch | zelda        | pichu | ness         | bowser         | kirby |
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+----------------+------------------+----------------+----------------+----------------+----------------+----------------+--------------+----------------+----------------+----------------+----------------+----------------+----------------+---------------+--------------+---------------+----------------+--------------+-------+--------------+----------------+-------+
| PEACH          | 689                | 452        | 65.6           | 51.91% (95/183)  | 71.74% (132/184) | 70.75% (75/106)  | 25.71% (9/35)  | 73.4% (69/94)    |                |                |                |                | 100.0% (6/6)   |              | 76.92% (10/13) |                |                | 85.71% (6/7)   | 81.82% (9/11)  | 70.0% (7/10)   |               |              |               |                |              |       |              |                |       |
| LINK           | 1805               | 1030       | 57.06          | 43.32% (107/247) | 58.31% (242/415) | 64.33% (220/342) | 47.92% (23/48) | 57.32% (141/246) | 40.35% (23/57) | 45.61% (26/57) | 57.69% (15/26) | 50.0% (14/28)  | 53.85% (14/26) | 30.0% (3/10) | 37.93% (11/29) | 55.56% (15/27) | 58.82% (20/34) | 90.48% (19/21) | 58.62% (34/58) | 78.38% (29/37) | 63.64% (7/11) | 57.14% (4/7) | 95.0% (19/20) | 77.78% (7/9)   | 66.67% (6/9) |       | 55.56% (5/9) | 86.67% (13/15) |       |
| MARTH          | 54                 | 28         | 51.85          | 42.11% (8/19)    | 42.86% (3/7)     | 63.64% (7/11)    |                | 50.0% (3/6)      |                |                |                |                |                |              |                |                |                |                |                |                |               |              |               |                |              |       |              |                |       |
| FALCO          | 1236               | 586        | 47.41          | 33.56% (99/295)  | 46.71% (78/167)  | 61.8% (165/267)  | 44.44% (44/99) | 47.14% (66/140)  | 42.42% (14/33) | 28.57% (10/35) | 25.0% (2/8)    | 57.14% (12/21) | 37.5% (9/24)   | 33.33% (2/6) | 29.63% (8/27)  | 27.78% (5/18)  | 80.0% (12/15)  | 100.0% (11/11) | 60.0% (6/10)   | 70.0% (14/20)  | 83.33% (5/6)  |              | 85.71% (6/7)  | 61.54% (8/13)  |              |       |              |                |       |
| FOX            | 119                | 52         | 43.7           | 45.83% (11/24)   | 44.83% (13/29)   | 65.22% (15/23)   | 6.25% (1/16)   | 9.09% (1/11)     | 66.67% (6/9)   |                |                |                |                |              |                |                |                |                |                |                |               |              |               |                |              |       |              |                |       |
| CAPTAIN_FALCON | 30                 | 13         | 43.33          |                  |                  | 28.57% (2/7)     |                | 18.18% (2/11)    |                |                |                |                |                |              |                |                |                |                |                |                |               |              |               |                |              |       |              |                |       |
| GAME_AND_WATCH | 33                 | 12         | 36.36          |                  |                  | 22.22% (2/9)     |                | 25.0% (2/8)      |                |                |                |                |                |              |                |                |                |                |                |                |               |              |               |                |              |       |              |                |       |
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+----------------+------------------+----------------+----------------+----------------+----------------+----------------+--------------+----------------+----------------+----------------+----------------+----------------+----------------+---------------+--------------+---------------+----------------+--------------+-------+--------------+----------------+-------+
```