### PR TITLE
Add stage winrate matrix example

### DIFF
--- a/examples/win_rate_stage_matrix.sql
+++ b/examples/win_rate_stage_matrix.sql
@@ -1,0 +1,45 @@
+-- Calculate win rate against all characters encountered
+-- Supplement your own player code (in place of 'FRTZ#931') on lines 13 and 28
+
+WITH
+totals AS (
+  SELECT
+  character,
+    COUNT(*) total_games_played,
+    SUM(winner) total_wins,
+    ROUND((SUM(winner) * 100.0)/(COUNT(*) *100.0),4) * 100 AS total_win_rate
+  FROM players
+-- Change this to your own player code
+  WHERE code = 'FRTZ#931'
+  GROUP BY character),
+character_mus AS (
+  SELECT
+    me.character,
+    COUNT(*) AS games_played,
+    SUM(me.winner) AS wins,
+    ROUND((SUM(me.winner) * 100.0)/(COUNT(*) * 100.0),4) * 100.0 AS win_rate,
+    op.character AS op_character,
+	games.stage
+  FROM players me, players op, games
+  WHERE op.id != me.id
+    AND me.game_id = op.game_id
+    AND me.game_id = games.id
+    AND NOT games.is_teams
+  -- Change this to your own player code
+  AND me.code = 'FRTZ#931'
+  GROUP BY me.character, stage
+  ORDER BY win_rate DESC),
+  reduce_set AS (
+  SELECT * FROM character_mus
+  -- Disregard low sample size MU's
+  WHERE games_played > 5)
+SELECT t.*,
+  MAX(CASE WHEN stage = 'BATTLEFIELD' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS battlefield,
+  MAX(CASE WHEN stage = 'DREAM_LAND_N64' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS dreamland,
+  MAX(CASE WHEN stage = 'YOSHIS_STORY' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS yoshis_story,
+  MAX(CASE WHEN stage = 'FINAL_DESTINATION' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS final_destination,
+  MAX(CASE WHEN stage = 'POKEMON_STADIUM' THEN win_rate || '% ' || char(40) || wins || '/' || games_played || char(41) END) AS pokemon_stadium
+FROM reduce_set rs
+JOIN totals t USING(character)
+GROUP BY character
+ORDER BY AVG(total_win_rate) DESC;


### PR DESCRIPTION
## What is the purpose of this PR?
This PR adds an example query which calculates each of your played character's win rates on the 5 tournament legal stages, across all games played.

This query is an adaptation of the character matrix example, it could be improved by requiring the query author to supply only one player code, but it should be serviceable as is.

## What is example output of this query?
```
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+-------------------+------------------+
| character      | total_games_played | total_wins | total_win_rate | battlefield      | dreamland        | yoshis_story     | final_destination | pokemon_stadium  |
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+-------------------+------------------+
| PEACH          | 689                | 452        | 65.6           | 71.2% (89/125)   | 69.23% (90/130)  | 54.9% (56/102)   | 66.36% (73/110)   | 66.95% (79/118)  |
| LINK           | 1805               | 1030       | 57.06          | 56.58% (172/304) | 63.57% (178/280) | 52.41% (163/311) | 56.85% (166/292)  | 55.21% (175/317) |
| MARTH          | 54                 | 28         | 51.85          | 20.0% (2/10)     | 62.5% (5/8)      | 70.0% (7/10)     | 40.0% (4/10)      | 66.67% (4/6)     |
| FALCO          | 1236               | 586        | 47.41          | 49.75% (98/197)  | 42.72% (88/206)  | 49.8% (124/249)  | 46.8% (95/203)    | 46.86% (97/207)  |
| FOX            | 119                | 52         | 43.7           | 26.09% (6/23)    | 56.25% (9/16)    | 50.0% (13/26)    | 57.89% (11/19)    | 25.0% (4/16)     |
| CAPTAIN_FALCON | 30                 | 13         | 43.33          | 16.67% (1/6)     |                  |                  |                   |                  |
| GAME_AND_WATCH | 33                 | 12         | 36.36          |                  | 33.33% (2/6)     | 16.67% (1/6)     | 42.86% (3/7)      |                  |
+----------------+--------------------+------------+----------------+------------------+------------------+------------------+-------------------+------------------+
```